### PR TITLE
push_update: Use personal access token authentication

### DIFF
--- a/push.sh
+++ b/push.sh
@@ -75,7 +75,7 @@ push_od() {
     echo "Pushing to Official devices"
     cd $devices_dir
     git add $target_device && git commit -m "Update $target_device"
-    git push https://github.com/RevengeOS-Devices/official_devices.git HEAD:master
+    git push git@github.com:RevengeOS-Devices/official_devices.git HEAD:master
     cd $mainpath
     rm -rf $devices_dir
 }
@@ -85,7 +85,7 @@ trigger() {
     git clone https://github.com/RevengeOS-Devices/ota_scripts.git $ota_scripts
     cd $ota_scripts
     echo "$(date)" > file && git add . && git commit -m "trigger"
-    git push https://github.com/RevengeOS-Devices/ota_scripts.git HEAD:master
+    git push git@github.com:RevengeOS-Devices/ota_scripts.git HEAD:master
     cd $mainpath
     rm -rf $ota_scripts
 }


### PR DESCRIPTION
remote: Support for password authentication was removed on August 13, 2021. Please use a personal access token instead.
remote: Please see https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/ for more information.